### PR TITLE
Change libsignal-c build system to cmake-ninja

### DIFF
--- a/im.dino.Dino.yml
+++ b/im.dino.Dino.yml
@@ -31,7 +31,7 @@ modules:
         url: https://download.gnome.org/sources/gspell/1.12/gspell-1.12.0.tar.xz
         sha256: 40d2850f1bb6e8775246fa1e39438b36caafbdbada1d28a19fa1ca07e1ff82ad
   - name: libsignal-protocol-c
-    buildsystem: cmake
+    buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_C_FLAGS=-fPIC
     cleanup:


### PR DESCRIPTION
The flathub CI would warn on it using cmake (with make), not sure why they didn’t just automatically make them use ninja instead of introducing a second build system enum but oh well.

Also, could you publish this to flathub master instead of beta?  This will make it tremendously easier for users to find it.