### PR TITLE
Use Marvin libsignal-protocol-c fork

### DIFF
--- a/im.dino.Dino.yml
+++ b/im.dino.Dino.yml
@@ -23,8 +23,8 @@ modules:
       - /lib
     sources:
       - type: git
-        url: https://github.com/WhisperSystems/libsignal-protocol-c.git
-        tag: v2.3.3
+        url: https://github.com/mar-v-in/libsignal-protocol-c.git
+        tag: v2.3.3.1
   - name: qrencode
     buildsystem: cmake-ninja
     cleanup:


### PR DESCRIPTION
Marvin is one of the maintainer of Dino.
There is a security issue in protobuf-c whose code was copy/pasted in libsignal-protocol-c

Marvin forked libsignal-protocol-c to use protobuf-c directly.